### PR TITLE
Update grader plugin dependency to v1.4.52

### DIFF
--- a/assignments/assignment3a/build.gradle
+++ b/assignments/assignment3a/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 
     dependencies {
 		// Required by Vanderbilt autograder - do not remove
-		classpath 'edu.vanderbilt.grader:gradle-plugin:1.4.51'
+		classpath 'edu.vanderbilt.grader:gradle-plugin:1.4.52'
         classpath "com.android.tools.build:gradle:$versions.android"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
     }


### PR DESCRIPTION
For some reason, v1.4.51 of the grader gradle plugin was [removed from Bintray/JCenter](https://bintray.com/montecreasor/grader/gradle-plugin). This is preventing any builds because Gradle can't find the dependency. A new version, v1.4.52, was released on March 12th, and it seems to work fine.